### PR TITLE
Allow using authenticator object for http

### DIFF
--- a/multiurl/base.py
+++ b/multiurl/base.py
@@ -71,6 +71,7 @@ class DownloaderBase:
         resume_transfers=False,
         override_target_file=True,
         download_file_extension=None,
+        auth=None,
         **kwargs,
     ):
         self.url = url
@@ -83,6 +84,7 @@ class DownloaderBase:
         self.resume_transfers = resume_transfers
         self.override_target_file = override_target_file
         self.download_file_extension = download_file_extension
+        self.auth = auth
 
     def mutate(self, *args, **kwargs):
         return self

--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -222,6 +222,7 @@ class HTTPDownloaderBase(DownloaderBase):
             verify=self.verify,
             timeout=self.timeout,
             headers=headers,
+            auth=self.auth,
         )
         try:
             r.raise_for_status()

--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -75,6 +75,7 @@ class HTTPDownloaderBase(DownloaderBase):
                         verify=self.verify,
                         timeout=self.timeout,
                         allow_redirects=True,
+                        auth=self.auth,
                     )
                     r.raise_for_status()
                     for k, v in r.headers.items():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,96 @@
+# (C) Copyright 2021 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import logging
+import os
+
+from multiurl import download
+
+# NOTE: we just test if the auth object is properly called with the
+# requests when using download()
+
+
+class Auth:
+    def __init__(self):
+        self.urls = []
+
+    def __call__(self, r):
+        self.urls.append(r.url)
+        return r
+
+
+def test_auth_single():
+    auth = Auth()
+    url = "http://get.ecmwf.int/test-data/metview/gallery/temp.bufr"
+    download(url=url, target="out.data", auth=auth)
+
+    assert auth.urls == [url]
+
+
+def test_auth_single_parts():
+    auth = Auth()
+    url = "http://get.ecmwf.int/test-data/metview/gallery/temp.bufr"
+
+    download(url=url, target="out.data", parts=((0, 4),), auth=auth)
+
+    assert auth.urls == [url]
+    assert os.path.getsize("out.data") == 4
+
+    with open("out.data", "rb") as f:
+        assert f.read() == b"BUFR"
+
+
+def test_auth_single_parts():
+    auth = Auth()
+    url = "http://get.ecmwf.int/test-data/metview/gallery/temp.bufr"
+
+    download(url=url, target="out.data", parts=((0, 4), (20, 4)), auth=auth)
+
+    assert auth.urls == [url]
+    assert os.path.getsize("out.data") == 8
+
+    with open("out.data", "rb") as f:
+        assert f.read(4) == b"BUFR"
+
+
+def test_auth_multi():
+    auth = Auth()
+    urls = [
+        "http://get.ecmwf.int/test-data/earthkit-data/examples/test.grib",
+        "http://get.ecmwf.int/test-data/earthkit-data/examples/test6.grib",
+    ]
+
+    download(url=urls, target="out.data", auth=auth)
+
+    assert auth.urls == urls
+    assert os.path.getsize("out.data") == 2492
+
+    with open("out.data", "rb") as f:
+        assert f.read(4) == b"GRIB"
+
+
+def test_auth_multi_parts():
+    auth = Auth()
+    urls = [
+        "http://get.ecmwf.int/test-data/earthkit-data/examples/test.grib",
+        "http://get.ecmwf.int/test-data/earthkit-data/examples/test6.grib",
+    ]
+
+    download(url=urls, target="out.data", parts=((0, 4),), auth=auth)
+
+    assert auth.urls == urls
+    assert os.path.getsize("out.data") == 8
+
+    with open("out.data", "rb") as f:
+        assert f.read(4) == b"GRIB"
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    # test_order()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -106,6 +106,7 @@ def test_auth_multi_parts():
 
     with open("out.data", "rb") as f:
         assert f.read(4) == b"GRIB"
+        assert f.read(4) == b"GRIB"
 
 
 if __name__ == "__main__":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -46,7 +46,7 @@ def test_auth_single_parts():
         assert f.read() == b"BUFR"
 
 
-def test_auth_single_parts():
+def test_auth_single_multi_parts():
     auth = Auth()
     url = "http://get.ecmwf.int/test-data/metview/gallery/temp.bufr"
 


### PR DESCRIPTION
This PR implements the `auth` keyword argument (the default is `auth=None`) in`download()` for http. It can take any authenticator objects accepted by `requests` as described here: 

https://requests.readthedocs.io/en/latest/user/authentication/

At the moment, only a single authenticator can be specified. So when multiple URLs are used in `download()` the same authenticator will be applied for all. 