### PR TITLE
Add support for retry-after header

### DIFF
--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -452,7 +452,9 @@ RETRIABLE = (
 )
 
 
-def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
+def robust(
+    call, maximum_tries=500, retry_after=120, mirrors=None, respect_retry_header=False
+):
     def retriable(code):
         return code in RETRIABLE
 
@@ -509,6 +511,29 @@ def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
                 LOG.warning("Retrying using mirror %s", mirror)
                 main_url = f"{mirror}{url[replace:]}"
             else:
+                nonlocal retry_after
+                retry_header = getattr(r, "headers", {}).get("Retry-After")
+                if respect_retry_header and retry_header is not None:
+                    try:
+                        # seconds
+                        retry_after = int(retry_header)
+                    except ValueError:
+                        try:
+                            # http date
+                            retry_date = datetime.datetime.strptime(
+                                retry_header, "%a, %d %b %Y %H:%M:%S GMT"
+                            )
+
+                            gmt = pytz.timezone("GMT")
+                            now = datetime.datetime.now(gmt)
+                            retry_date = gmt.localize(retry_date)
+                            retry_sec = (retry_date - now).total_seconds()
+
+                            if retry_sec > 0:
+                                retry_after = retry_sec
+                        except Exception:
+                            pass
+
                 LOG.warning("Retrying in %s seconds", retry_after)
                 time.sleep(retry_after)
                 LOG.info("Retrying now...")

--- a/tests/test_robust.py
+++ b/tests/test_robust.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+import datetime
 import logging
 import os
 import random
@@ -14,9 +15,11 @@ import threading
 from contextlib import contextmanager
 
 import pytest
+import pytz
+import requests
 
 from multiurl import download
-from multiurl.http import RETRIABLE
+from multiurl.http import RETRIABLE, robust
 
 
 def handler(signum, frame):
@@ -45,6 +48,32 @@ def test_robust():
             retry_after=sleep,
             target="test.data",
         )
+
+
+def test_retry_header():
+    # patch requests.get to add a Retry-After header
+    def patched_get(retry, *args, **kwargs):
+        r = requests.get(*args, **kwargs)
+        if callable(retry):
+            retry = retry()
+        r.headers.update({"Retry-After": retry})
+        return r
+
+    def http_date():
+        gmt = pytz.timezone("GMT")
+        now = datetime.datetime.now(gmt)
+        return (now + datetime.timedelta(seconds=10)).strftime(
+            "%a, %d %b %Y %H:%M:%S GMT"
+        )
+
+    # test with seconds and http date format
+    for retry in ["5", http_date]:
+        with timeout(60):
+            code = random.choice(RETRIABLE)
+            r = robust(
+                patched_get, maximum_tries=2, retry_after=120, respect_retry_header=True
+            )(retry, f"http://httpbin.org/status/{code}")
+            assert r.status_code == code
 
 
 @pytest.mark.skipif(True, reason="Mirror disabled")


### PR DESCRIPTION
Add support for the [Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header to `robust`. I placed it behind an optional flag `respect_retry_header`, so default behaviour is unchanged. It's a bit of a niche feature, but it could be useful when using `robust` directly in an api client.

Supports both seconds and http date format of the header. 

Includes tests.