### PR TITLE
Fix content-disposition handling

### DIFF
--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -111,8 +111,8 @@ class HTTPDownloaderBase(DownloaderBase):
             headers = self.headers()
 
             if "content-disposition" in headers:
-                value, params = parse_separated_header(headers["content-disposition"])
-                assert value == "attachment", value
+                params = parse_separated_header(headers["content-disposition"])
+                assert "attachment" in params, params
                 if "filename" in params:
                     ext = super().extension(params["filename"])
 
@@ -121,7 +121,7 @@ class HTTPDownloaderBase(DownloaderBase):
     def title(self):
         headers = self.headers()
         if "content-disposition" in headers:
-            value, params = parse_separated_header(headers["content-disposition"])
+            params = parse_separated_header(headers["content-disposition"])
             if "filename" in params:
                 return params["filename"]
         return super().title()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -13,6 +13,7 @@ import os
 import pytest
 
 from multiurl import Downloader, download
+from multiurl.http import FullHTTPDownloader
 
 
 def test_http():
@@ -75,6 +76,18 @@ def test_order():
 
     with open("out.data", "rb") as f:
         assert f.read()[:4] == b"BUFR"
+
+
+def test_content_disposition_handling():
+    class TestDownloader(FullHTTPDownloader):
+        def headers(self):
+            headers = super().headers()
+            headers["content-disposition"] = 'attachment; filename="temp.bufr"'
+            return headers
+
+    TestDownloader(
+        url="http://get.ecmwf.int/test-data/metview/gallery/temp.bufr",
+    ).download(target="out")
 
 
 @pytest.mark.skip(reason="ftpserver not defined")


### PR DESCRIPTION
This should resolve #21 which should also solve
https://github.com/ecmwf/ecmwf-opendata/issues/54.

The parsing function returns a dictionary, not a tuple. If we tuple-unpack a dictionary, that will give us the keys of the *first two* dictionary entries. If there are more than two entries it would raise a ValueError (too many values to unpack).