### PR TITLE
retry on ChunkedEncodingError

### DIFF
--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -392,7 +392,7 @@ class PartHTTPDownloader(HTTPDownloaderBase):
     def split_large_requests(self, parts):
         ranges = []
         for offset, length in parts:
-            ranges.append(f"{offset}-{offset+length-1}")
+            ranges.append(f"{offset}-{offset + length - 1}")
 
         # Nginx default is 4K
         # https://stackoverflow.com/questions/686217/maximum-on-http-header-values
@@ -498,6 +498,7 @@ def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
             except (
                 requests.exceptions.ConnectionError,
                 requests.exceptions.ReadTimeout,
+                requests.exceptions.ChunkedEncodingError,
             ) as e:
                 r = None
                 LOG.warning(

--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -392,7 +392,7 @@ class PartHTTPDownloader(HTTPDownloaderBase):
     def split_large_requests(self, parts):
         ranges = []
         for offset, length in parts:
-            ranges.append(f"{offset}-{offset + length - 1}")
+            ranges.append(f"{offset}-{offset+length-1}")
 
         # Nginx default is 4K
         # https://stackoverflow.com/questions/686217/maximum-on-http-header-values


### PR DESCRIPTION
### Description
Would it be possible to add ChunkedEncodingError in the list of errors that the robust wrapper retries?

See: https://github.com/ecmwf/ecmwf-datastores-client/issues/23

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 