### PR TITLE
Allow robust to use the server-suggested Retry-After header

### DIFF
--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -465,7 +465,13 @@ def _logged_sleep(seconds):
     time.sleep(seconds)
 
 
-def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
+def robust(
+    call,
+    maximum_tries=500,
+    retry_after=120,
+    mirrors=None,
+    use_server_retry_after=False,
+):
     def retriable(code):
         return code in RETRIABLE
 
@@ -540,7 +546,11 @@ def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
                 main_url = f"{mirror}{url[replace:]}"
             else:
                 server_sleep = None
-                if r is not None and "retry-after" in r.headers:
+                if (
+                    use_server_retry_after
+                    and r is not None
+                    and "retry-after" in r.headers
+                ):
                     try:
                         server_sleep = float(r.headers["retry-after"])
                     except ValueError:

--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -460,6 +460,11 @@ RETRIABLE = (
 )
 
 
+def _logged_sleep(seconds):
+    LOG.warning(f"Retrying in {seconds} seconds")
+    time.sleep(seconds)
+
+
 def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
     def retriable(code):
         return code in RETRIABLE
@@ -534,13 +539,22 @@ def robust(call, maximum_tries=500, retry_after=120, mirrors=None):
                 LOG.warning("Retrying using mirror %s", mirror)
                 main_url = f"{mirror}{url[replace:]}"
             else:
-                LOG.warning("Retrying in %s seconds", sleep)
-                time.sleep(sleep)
-                sleep = (
-                    min(sleep * sleep_incremental_ratio, sleep_max)
-                    if sleep_incremental_ratio >= 1
-                    else max(sleep_min, sleep * sleep_incremental_ratio)
-                )
+                server_sleep = None
+                if r is not None and "retry-after" in r.headers:
+                    try:
+                        server_sleep = float(r.headers["retry-after"])
+                    except ValueError:
+                        pass
+
+                if server_sleep is not None:
+                    _logged_sleep(server_sleep)
+                else:
+                    _logged_sleep(sleep)
+                    sleep = (
+                        min(sleep * sleep_incremental_ratio, sleep_max)
+                        if sleep_incremental_ratio >= 1
+                        else max(sleep_min, sleep * sleep_incremental_ratio)
+                    )
                 LOG.info("Retrying now...")
 
     return wrapped

--- a/tests/test_robust.py
+++ b/tests/test_robust.py
@@ -97,6 +97,26 @@ def test_mirror():
     )
 
 
+@pytest.mark.parametrize(
+    "use_server_retry_after,expected_log",
+    [(True, "Retrying in 0.1 seconds"), (False, "Retrying in 0.2 seconds")],
+)
+def test_robust_use_server_retry_after(caplog, use_server_retry_after, expected_log):
+    def patched_get(*args, **kwargs):
+        r = requests.get(*args, **kwargs)
+        r.headers["Retry-After"] = "0.1"
+        return r
+
+    robust_get = robust(
+        patched_get,
+        maximum_tries=2,
+        retry_after=0.2,
+        use_server_retry_after=use_server_retry_after,
+    )
+    robust_get(f"http://httpbin.org/status/429")
+    assert caplog.record_tuples[-1][-1] == expected_log
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     test_mirror()

--- a/tests/test_robust.py
+++ b/tests/test_robust.py
@@ -113,7 +113,7 @@ def test_robust_use_server_retry_after(caplog, use_server_retry_after, expected_
         retry_after=0.2,
         use_server_retry_after=use_server_retry_after,
     )
-    robust_get(f"http://httpbin.org/status/429")
+    robust_get("http://httpbin.org/status/429")
     assert caplog.record_tuples[-1][-1] == expected_log
 
 


### PR DESCRIPTION
### Description

The Retry-After HTTP response header indicates how long the user agent should wait before making a follow-up request. This PR allows to use the server-suggested retry_after value and is implemented as an opt-in feature to avoid breaking changes.

The HTTP specification allows Retry-After to be provided either as a delay in seconds or as a date. I believe the latter is out of scope for this use case, which motivates the try/except used to convert the string to a float.

Side note: The Data Stores Service does provide a Retry-After value with 429 errors.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 