### PR TITLE
Keep requests session open in S3Streamer

### DIFF
--- a/multiurl/multipart.py
+++ b/multiurl/multipart.py
@@ -21,6 +21,7 @@ class S3Streamer:
     def __init__(self, url, request, parts, headers, **kwargs):
         self.url = url
         self.parts = parts
+        self.session = requests.session()
         self.request = request
         self.headers = dict(**headers)
         self.kwargs = kwargs
@@ -37,7 +38,7 @@ class S3Streamer:
             else:
                 offset, length = part
                 headers["range"] = f"bytes={offset}-{offset+length-1}"
-                request = requests.get(
+                request = self.session.get(
                     self.url,
                     stream=True,
                     headers=headers,


### PR DESCRIPTION
### Description
When downloading many chunks of files, a supervisor thread is run for each of them, causing 'too many open files' error. This patch uses only one session per S3 instance.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 