### PR TITLE
Use retry in S3Streamer

### DIFF
--- a/multiurl/__init__.py
+++ b/multiurl/__init__.py
@@ -8,12 +8,13 @@
 #
 
 
-from .downloader import Downloader, download, robust
+from .downloader import Downloader, download
+from .retry import robust
 
 __version__ = "0.3.8dev0"
 
 __all__ = [
     "download",
     "Downloader",
-    "robust",
+    "robust"
 ]

--- a/multiurl/http.py
+++ b/multiurl/http.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from .base import DownloaderBase
 from .multipart import DecodeMultipart, PartFilter, compute_byte_ranges
+from .retry import robust
 
 LOG = logging.getLogger(__name__)
 
@@ -339,8 +340,10 @@ class SinglePartHTTPDownloader(HTTPDownloaderBase):
         request = self.issue_request(self.bytes_range)
         return request.iter_content
 
+
 class PartHTTPDownloader(HTTPDownloaderBase):
-    def __init__(self, 
+    def __init__(
+        self,
         *args,
         accept_ranges: Optional[bool] = None,
         accept_multiple_ranges: Optional[bool] = None,
@@ -483,128 +486,11 @@ class PartHTTPDownloader(HTTPDownloaderBase):
                     verify=self.verify,
                     timeout=self.timeout,
                     headers=self.http_headers,
+                    maximum_retries=self.maximum_retries,
+                    retry_after=self.retry_after,
+                    mirrors=self.mirrors,
                 )
 
                 yield from stream(chunk_size)
 
         return filter(iterate_requests)
-
-
-RETRIABLE = (
-    requests.codes.internal_server_error,
-    requests.codes.bad_gateway,
-    requests.codes.service_unavailable,
-    requests.codes.gateway_timeout,
-    requests.codes.too_many_requests,
-    requests.codes.request_timeout,
-)
-
-
-def _logged_sleep(seconds):
-    LOG.warning(f"Retrying in {seconds} seconds")
-    time.sleep(seconds)
-
-
-def robust(
-    call,
-    maximum_tries=500,
-    retry_after=120,
-    mirrors=None,
-    use_server_retry_after=False,
-):
-    def retriable(code):
-        return code in RETRIABLE
-
-    def wrapped(url, *args, **kwargs):
-        tries = 0
-        main_url = url
-
-        if isinstance(retry_after, (list, tuple)):
-            sleep_min, sleep_max, sleep_incremental_ratio = retry_after
-        elif isinstance(retry_after, (int, float)):
-            sleep_min = sleep_max = retry_after
-            sleep_incremental_ratio = 1
-        else:
-            raise TypeError("retry_after must be int, float, tuple, or list")
-
-        assert sleep_min >= 0 and sleep_incremental_ratio > 0
-        assert (
-            sleep_min == sleep_max
-            if sleep_incremental_ratio == 1
-            else sleep_min < sleep_max
-        )
-        sleep = sleep_min if sleep_incremental_ratio >= 1 else sleep_max
-
-        while True:
-            tries += 1
-
-            if tries >= maximum_tries:
-                # Last attempt, don't do anything
-                return call(main_url, *args, **kwargs)
-
-            try:
-                r = call(main_url, *args, **kwargs)
-            except requests.exceptions.SSLError:
-                raise
-            except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.ChunkedEncodingError,
-            ) as e:
-                r = None
-                LOG.warning(
-                    "Recovering from connection error [%s], attempt %s of %s",
-                    e,
-                    tries,
-                    maximum_tries,
-                )
-
-            if r is not None:
-                if not retriable(r.status_code):
-                    return r
-                LOG.warning(
-                    "Recovering from HTTP error [%s %s], attempt %s of %s",
-                    r.status_code,
-                    r.reason,
-                    tries,
-                    maximum_tries,
-                )
-
-            alternate = None
-            replace = 0
-            if mirrors is not None:
-                for key, values in mirrors.items():
-                    if url.startswith(key):
-                        alternate = values
-                        replace = len(key)
-                        if not isinstance(alternate, (list, tuple)):
-                            alternate = [alternate]
-
-            if alternate is not None:
-                mirror = random.choice(alternate)
-                LOG.warning("Retrying using mirror %s", mirror)
-                main_url = f"{mirror}{url[replace:]}"
-            else:
-                server_sleep = None
-                if (
-                    use_server_retry_after
-                    and r is not None
-                    and "retry-after" in r.headers
-                ):
-                    try:
-                        server_sleep = float(r.headers["retry-after"])
-                    except ValueError:
-                        pass
-
-                if server_sleep is not None:
-                    _logged_sleep(server_sleep)
-                else:
-                    _logged_sleep(sleep)
-                    sleep = (
-                        min(sleep * sleep_incremental_ratio, sleep_max)
-                        if sleep_incremental_ratio >= 1
-                        else max(sleep_min, sleep * sleep_incremental_ratio)
-                    )
-                LOG.info("Retrying now...")
-
-    return wrapped

--- a/multiurl/multipart.py
+++ b/multiurl/multipart.py
@@ -8,21 +8,33 @@
 #
 import logging
 import re
-
 import requests
 
 from .heuristics import Part, parts_heuristics
+from .retry import robust
 
 LOG = logging.getLogger(__name__)
 
 
 # S3 does not support multiple ranges
 class S3Streamer:
-    def __init__(self, url, request, parts, headers, **kwargs):
+    def __init__(self, 
+        url,
+        request,
+        parts,
+        headers,
+        retry_after=120,
+        maximum_retries=500,
+        mirrors=None,
+        **kwargs
+    ):
         self.url = url
         self.parts = parts
         self.request = request
         self.headers = dict(**headers)
+        self.retry_after = retry_after
+        self.maximum_retries = maximum_retries
+        self.mirrors = mirrors
         self.kwargs = kwargs
 
     def __call__(self, chunk_size):
@@ -37,7 +49,7 @@ class S3Streamer:
             else:
                 offset, length = part
                 headers["range"] = f"bytes={offset}-{offset+length-1}"
-                request = requests.get(
+                request = self.robust(requests.get)(
                     self.url,
                     stream=True,
                     headers=headers,
@@ -69,6 +81,9 @@ class S3Streamer:
             )
 
             yield from request.iter_content(chunk_size)
+    
+    def robust(self, call):
+        return robust(call, self.maximum_retries, self.retry_after, self.mirrors)
 
 
 class MultiPartStreamer:

--- a/multiurl/retry.py
+++ b/multiurl/retry.py
@@ -1,0 +1,124 @@
+import logging
+import requests
+import time
+
+LOG = logging.getLogger(__name__)
+
+RETRIABLE = (
+    requests.codes.internal_server_error,
+    requests.codes.bad_gateway,
+    requests.codes.service_unavailable,
+    requests.codes.gateway_timeout,
+    requests.codes.too_many_requests,
+    requests.codes.request_timeout,
+)
+
+
+def _logged_sleep(seconds):
+    LOG.warning(f"Retrying in {seconds} seconds")
+    time.sleep(seconds)
+
+
+def robust(
+    call,
+    maximum_tries=500,
+    retry_after=120,
+    mirrors=None,
+    use_server_retry_after=False,
+):
+    def retriable(code):
+        return code in RETRIABLE
+
+    def wrapped(url, *args, **kwargs):
+        tries = 0
+        main_url = url
+
+        if isinstance(retry_after, (list, tuple)):
+            sleep_min, sleep_max, sleep_incremental_ratio = retry_after
+        elif isinstance(retry_after, (int, float)):
+            sleep_min = sleep_max = retry_after
+            sleep_incremental_ratio = 1
+        else:
+            raise TypeError("retry_after must be int, float, tuple, or list")
+
+        assert sleep_min >= 0 and sleep_incremental_ratio > 0
+        assert (
+            sleep_min == sleep_max
+            if sleep_incremental_ratio == 1
+            else sleep_min < sleep_max
+        )
+        sleep = sleep_min if sleep_incremental_ratio >= 1 else sleep_max
+
+        while True:
+            tries += 1
+
+            if tries >= maximum_tries:
+                # Last attempt, don't do anything
+                return call(main_url, *args, **kwargs)
+
+            try:
+                r = call(main_url, *args, **kwargs)
+            except requests.exceptions.SSLError:
+                raise
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ReadTimeout,
+                requests.exceptions.ChunkedEncodingError,
+            ) as e:
+                r = None
+                LOG.warning(
+                    "Recovering from connection error [%s], attempt %s of %s",
+                    e,
+                    tries,
+                    maximum_tries,
+                )
+
+            if r is not None:
+                if not retriable(r.status_code):
+                    return r
+                LOG.warning(
+                    "Recovering from HTTP error [%s %s], attempt %s of %s",
+                    r.status_code,
+                    r.reason,
+                    tries,
+                    maximum_tries,
+                )
+
+            alternate = None
+            replace = 0
+            if mirrors is not None:
+                for key, values in mirrors.items():
+                    if url.startswith(key):
+                        alternate = values
+                        replace = len(key)
+                        if not isinstance(alternate, (list, tuple)):
+                            alternate = [alternate]
+
+            if alternate is not None:
+                mirror = random.choice(alternate)
+                LOG.warning("Retrying using mirror %s", mirror)
+                main_url = f"{mirror}{url[replace:]}"
+            else:
+                server_sleep = None
+                if (
+                    use_server_retry_after
+                    and r is not None
+                    and "retry-after" in r.headers
+                ):
+                    try:
+                        server_sleep = float(r.headers["retry-after"])
+                    except ValueError:
+                        pass
+
+                if server_sleep is not None:
+                    _logged_sleep(server_sleep)
+                else:
+                    _logged_sleep(sleep)
+                    sleep = (
+                        min(sleep * sleep_incremental_ratio, sleep_max)
+                        if sleep_incremental_ratio >= 1
+                        else max(sleep_min, sleep * sleep_incremental_ratio)
+                    )
+                LOG.info("Retrying now...")
+
+    return wrapped

--- a/tests/test_robust.py
+++ b/tests/test_robust.py
@@ -17,7 +17,7 @@ import pytest
 import requests
 
 from multiurl import download
-from multiurl.http import RETRIABLE, robust
+from multiurl.retry import RETRIABLE, robust
 
 
 def handler(signum, frame):
@@ -54,25 +54,25 @@ def test_robust():
         [
             0.1,
             [
-                ("multiurl.http", 30, "Retrying in 0.1 seconds"),
-                ("multiurl.http", 30, "Retrying in 0.1 seconds"),
-                ("multiurl.http", 30, "Retrying in 0.1 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.1 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.1 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.1 seconds"),
             ],
         ],
         [
             (0.1, 0.2, 2),
             [
-                ("multiurl.http", 30, "Retrying in 0.1 seconds"),
-                ("multiurl.http", 30, "Retrying in 0.2 seconds"),
-                ("multiurl.http", 30, "Retrying in 0.2 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.1 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.2 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.2 seconds"),
             ],
         ],
         [
             (0.1, 0.2, 0.5),
             [
-                ("multiurl.http", 30, "Retrying in 0.2 seconds"),
-                ("multiurl.http", 30, "Retrying in 0.1 seconds"),
-                ("multiurl.http", 30, "Retrying in 0.1 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.2 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.1 seconds"),
+                ("multiurl.retry", 30, "Retrying in 0.1 seconds"),
             ],
         ],
     ],


### PR DESCRIPTION
### Description
The `S3Streamer` performs get requests which were not wrapped into a `robust` method up until now. When requesting data from AWS using the `ecmwf-opendata` package, one often gets `503 Slow Down` errors on which no retry is executed. Now, the requests by the `S3Streamer` are wrapped by the `robust` method.

I moved the `robust` method into a `retry.py` module to avoid circular imports.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
